### PR TITLE
新規登録画面での設計重量の計算と表示

### DIFF
--- a/app/assets/javascripts/calculation_weight.js
+++ b/app/assets/javascripts/calculation_weight.js
@@ -1,0 +1,13 @@
+$(function () {
+  $("#product_design").on("change", function () {
+    let valueLength = $("#product_length").val();
+    let valueWidth = $("#product_width").val();
+    let valueBasisWeight = $("#product_material_id option:selected").attr("basis_weight");
+
+    let calculationWeight = (parseFloat(valueLength) * parseFloat(valueWidth) * parseFloat(valueBasisWeight) / 100).toFixed(1);
+
+    if (calculationWeight > 0) {
+      $("#calculation-weight").val(calculationWeight);
+    };
+  });
+});

--- a/app/views/products/_new-product.html.haml
+++ b/app/views/products/_new-product.html.haml
@@ -1,7 +1,7 @@
 .main-content__new-product
   新規登録
   = form_with(model: @product, local: true) do |form|
-    .form
+    .form#product_design
       .info
         製品番号
         = form.text_field :number, class: "info__input", readonly: "readonly", id: "number", value: @new_number
@@ -13,7 +13,7 @@
         前回品と同設計で入力
       .info
         材質
-        = form.select :material_id, options_for_select(@material.map{|material|[material[:name], material[:id], {}]}, ""), {}, {class: "info__input"}
+        = form.select :material_id, options_for_select(@material.map{|material|[material[:name], material[:id], {"basis_weight"=>material[:basis_weight]}]}, ""), {}, {class: "info__input"}
       .info-size.clearfix
         設計寸法
         .info-size__size
@@ -22,8 +22,7 @@
           = form.text_field :width, class: "input"
           cm
         .info-size__weight
-          仮入力
-          -# = #次の計算結果→length * width * material.basis-weight
+          %input#calculation-weight.info__output{type: "text",readonly: "readonly"}
           kg
       = form.submit "登録", class: "submit-btn"
   = link_to "ホームへ戻る", root_path, class: "root-path"


### PR DESCRIPTION
# what
新規登録画面において、設計重量を自動表示させる。
設計重量の値は、フォームに入力されたlengthとwidth、および選択されたmaterial.basis_weightの三つ値の積とし、javascriptによって入力値と連動して表示させる。

# why
lengthとwidth、およびmaterial.basis_weightは手動で入力されるべきだが、設計重量はこれらの値によって決定されるものであり、手動の入力とする事は不適であるため。