### PR TITLE
ゲストログイン機能の実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :check_guest, only: [:update, :destroy]
+
+  def check_guest
+    if resource.number == (990001 || 990002)
+      redirect_to root_path, alert: 'テストユーザーの変更・削除はできません。'
+    end
+  end
+
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,6 +6,12 @@ class Users::SessionsController < Devise::SessionsController
     sign_in user
     redirect_to root_path
   end
+
+  def new_sales_guest
+    user = User.sales_guest
+    sign_in user
+    redirect_to root_path
+  end
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  def new_production_guest
+    user = User.production_guest
+    sign_in user
+    redirect_to root_path
+  end
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -12,6 +12,17 @@ class Users::SessionsController < Devise::SessionsController
     sign_in user
     redirect_to root_path
   end
+
+  def change_to_production_guest
+    sign_out current_user
+    new_production_guest
+  end
+
+  def change_to_sales_guest
+    sign_out current_user
+    new_sales_guest
+  end
+
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,12 @@ class User < ApplicationRecord
   def will_save_change_to_email?
     false
   end
+
+  def self.production_guest
+    find_or_create_by!(number: "253253") do |user|
+      user.name = "テストユーザー（製造部員）"
+      user.department_id = 1
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,9 +26,17 @@ class User < ApplicationRecord
   end
 
   def self.production_guest
-    find_or_create_by!(number: "253253") do |user|
+    find_or_create_by!(number: "990001") do |user|
       user.name = "テストユーザー（製造部員）"
       user.department_id = 1
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
+
+  def self.sales_guest
+    find_or_create_by!(number: "990002") do |user|
+      user.name = "テストユーザー（営業部員）"
+      user.department_id = 2
       user.password = SecureRandom.urlsafe_base64
     end
   end

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -14,3 +14,4 @@
           = form.submit "ログイン"
 
   .main-content
+    = link_to "製造部アカウントでゲストログイン", users_production_guest_sign_in_path, method: :post

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -15,3 +15,5 @@
 
   .main-content
     = link_to "製造部アカウントでゲストログイン", users_production_guest_sign_in_path, method: :post
+    %br
+    = link_to "営業部アカウントでゲストログイン", users_sales_guest_sign_in_path, method: :post

--- a/app/views/products/_user-name.html.haml
+++ b/app/views/products/_user-name.html.haml
@@ -3,3 +3,8 @@
     .info__output
       = current_user.name
     = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'info__logout'
+    %br
+      - if current_user.number == "990001"
+        = link_to "営業部アカウントへ切り替える", users_change_to_sales_guest_path, method: :post
+      - if current_user.number == "990002"
+        = link_to "製造部アカウントへ切り替える", users_change_to_production_guest_path, method: :post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    sessions: "users/sessions"
+    sessions: "users/sessions",
+    registrations: "users/registrations"
   }
   devise_scope :user do
     post "users/production_guest_sign_in", to: "users/sessions#new_production_guest"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   devise_scope :user do
     post "users/production_guest_sign_in", to: "users/sessions#new_production_guest"
     post "users/sales_guest_sign_in", to: "users/sessions#new_sales_guest"
+    post "users/change_to_production_guest", to: "users/sessions#change_to_production_guest"
+    post "users/change_to_sales_guest", to: "users/sessions#change_to_sales_guest"
   end
   root "products#index"
   resources :products, only: [:new, :create, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   }
   devise_scope :user do
     post "users/production_guest_sign_in", to: "users/sessions#new_production_guest"
+    post "users/sales_guest_sign_in", to: "users/sessions#new_sales_guest"
   end
   root "products#index"
   resources :products, only: [:new, :create, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    sessions: "users/sessions"
+  }
+  devise_scope :user do
+    post "users/production_guest_sign_in", to: "users/sessions#new_production_guest"
+  end
   root "products#index"
   resources :products, only: [:new, :create, :show] do
     collection do


### PR DESCRIPTION
# what
ゲストユーザーアカウントを用いて、IDやパスワード不要でログインできる様にする。
ゲストユーザーは、製造部員版と営業部員版をそれぞれ作成する。
閲覧の操作性をよくするため、ゲストログイン後に製造部員版と営業部員版を切り替えられる機能も実装する。

# why
本制作物を評価していただくに当たり、ログイン/ログアウトの手間を可能な限り省略するため。